### PR TITLE
Retirando o ícone de mais nas fotos de projetos

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,11 +222,6 @@
 		<!-- Informações de um projeto (1° coluna da linha) -->
           <div class="col-md-6 portfolio-item">
             <a class="portfolio-link" data-toggle="modal" href="#portfolioModal1">
-              <div class="portfolio-hover">
-                <div class="portfolio-hover-content">
-                  <i class="fa fa-plus fa-3x"></i>
-                </div>
-              </div>
               <img class="img-fluid" src="img/portfolio/ProjetoC.png" alt="">
             </a>
             <div class="portfolio-caption">
@@ -237,11 +232,6 @@
 		  
           <div class="col-md-6 portfolio-item">
             <a class="portfolio-link" data-toggle="modal" href="#portfolioModal2">
-              <div class="portfolio-hover">
-                <div class="portfolio-hover-content">
-                  <i class="fa fa-plus fa-3x"></i>
-                </div>
-              </div>
               <img class="img-fluid" src="img/portfolio/CursoExcel1-20181.jpg" alt="">
             </a>
             <div class="portfolio-caption">


### PR DESCRIPTION
Retirando o ícone de mais que aparecia sobre as fotos de projetos quando colocava o mouse em cima delas.